### PR TITLE
Remove jenkinsctl.log file generation

### DIFF
--- a/jenkinsctl/configs/logging_config.py
+++ b/jenkinsctl/configs/logging_config.py
@@ -9,11 +9,6 @@ def setup_logging(log_level=logging.INFO):
     console_handler.setLevel(log_level)
     console_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
 
-    file_handler = logging.FileHandler('jenkinsctl.log')
-    file_handler.setLevel(log_level)
-    file_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
-
     logger.addHandler(console_handler)
-    logger.addHandler(file_handler)
 
     return logger


### PR DESCRIPTION
## Remove jenkinsctl.log file generation

### Summary
This PR removes the automatic generation of the `jenkinsctl.log` file by eliminating the FileHandler from the logging configuration. All logging output will now only be directed to the console (stdout).

### Motivation
The `jenkinsctl.log` file was being automatically generated in the working directory whenever the tool was run. This behavior can be undesirable for several reasons:
- Creates clutter in user directories
- May contain sensitive information that users don't expect to be persisted
- Users who want file logging can redirect console output themselves (e.g., `jenkinsctl command > output.log`)
- Follows the Unix philosophy of writing to stdout by default

### Changes
- **Modified**: `jenkinsctl/configs/logging_config.py`
  - Removed `FileHandler` initialization
  - Removed file handler registration from logger
  - Retained `StreamHandler` for console output

### Testing
The logging functionality continues to work as expected, with all log messages appearing in the console. No functionality is lost - users can still capture logs by redirecting stdout if needed.

### Breaking Changes
None. This only affects where logs are written. The logging format, levels, and console output remain unchanged.